### PR TITLE
 Increase the promise library version to 3.0.1

### DIFF
--- a/dist/impUnit.nut
+++ b/dist/impUnit.nut
@@ -1,4 +1,4 @@
-#require "promise.class.nut:3.0.0"
+#require "promise.class.nut:3.0.1"
 #require "JSONEncoder.class.nut:2.0.0"
 // MIT License
 //

--- a/index.nut
+++ b/index.nut
@@ -1,4 +1,4 @@
-#require "promise.class.nut:3.0.0"
+#require "promise.class.nut:3.0.1"
 #require "JSONEncoder.class.nut:2.0.0"
 // MIT License
 //


### PR DESCRIPTION
Increase the promise library version to the 3.0.1 to provide more details on Promise-based tests cases failure.